### PR TITLE
Change "env" type of winpty_start_process

### DIFF
--- a/include/winpty.h
+++ b/include/winpty.h
@@ -25,6 +25,7 @@
 
 #include <stdlib.h>
 #include <windows.h>
+#include <string>
 
 #ifdef WINPTY
 #define WINPTY_API __declspec(dllexport)
@@ -77,7 +78,7 @@ WINPTY_API int winpty_start_process(winpty_t *pc,
                                     const wchar_t *appname,
                                     const wchar_t *cmdline,
                                     const wchar_t *cwd,
-                                    const wchar_t *env);
+                                    const std::wstring env);
 
 /*
  * Returns the exit code of the process started with winpty_start_process,

--- a/libwinpty/winpty.cc
+++ b/libwinpty/winpty.cc
@@ -461,7 +461,7 @@ WINPTY_API int winpty_start_process(winpty_t *pc,
                                     const wchar_t *appname,
                                     const wchar_t *cmdline,
                                     const wchar_t *cwd,
-                                    const wchar_t *env)
+                                    const std::wstring env)
 {
 
     WriteBuffer packet;
@@ -469,7 +469,7 @@ WINPTY_API int winpty_start_process(winpty_t *pc,
     packet.putWString(appname ? appname : L"");
     packet.putWString(cmdline ? cmdline : L"");
     packet.putWString(cwd ? cwd : L"");
-    packet.putWString(env ? env : L"");
+    packet.putWString(env);
     packet.putWString(getDesktopFullName());
     writePacket(pc, packet);
     return readInt32(pc);


### PR DESCRIPTION
Hi!
Actually, you send the environment as as wchar_.
The putWString of the Buffer Class send only the very first string (stop at the first NULL char), soo the environment is "cut" at the first line.
If we use a wstring, it can handle all the vars separated by NULL and finishing by 2_NULL (required format for the CreateProcess).
