### PR TITLE
Include <algorithm> for std::min and std::max

### DIFF
--- a/agent/NamedPipe.h
+++ b/agent/NamedPipe.h
@@ -24,6 +24,7 @@
 #include <windows.h>
 #include <string>
 #include <vector>
+#include <algorithm>
 
 class EventLoop;
 


### PR DESCRIPTION
Doesn't build on Windows because of this.
