### PR TITLE
Fix compilation errors related to C++11's new user-defined string lit…

### DIFF
--- a/agent/Terminal.cc
+++ b/agent/Terminal.cc
@@ -57,7 +57,7 @@ Terminal::Terminal(NamedPipe *output) :
 void Terminal::reset(bool sendClearFirst, int newLine)
 {
     if (sendClearFirst)
-        m_output->write(CSI"1;1H"CSI"2J");
+        m_output->write(CSI"1;1H" CSI"2J");
     m_remoteLine = newLine;
     m_cursorHidden = false;
     m_cursorPos = std::pair<int, int>(0, newLine);
@@ -162,7 +162,7 @@ void Terminal::finishOutput(const std::pair<int, int> &newCursorPos)
     if (m_cursorHidden) {
         moveTerminalToLine(newCursorPos.second);
         char buffer[32];
-        sprintf(buffer, CSI"%dG"CSI"?25h", newCursorPos.first + 1);
+        sprintf(buffer, CSI"%dG" CSI"?25h", newCursorPos.first + 1);
         m_output->write(buffer);
         m_cursorHidden = false;
     }
@@ -187,7 +187,7 @@ void Terminal::moveTerminalToLine(int line)
     if (line < m_remoteLine) {
         // CUrsor Up (CUU)
         char buffer[32];
-        sprintf(buffer, "\r"CSI"%dA", m_remoteLine - line);
+        sprintf(buffer, "\r" CSI"%dA", m_remoteLine - line);
         m_output->write(buffer);
         m_remoteLine = line;
     } else if (line > m_remoteLine) {

--- a/libwinpty/winpty.cc
+++ b/libwinpty/winpty.cc
@@ -136,7 +136,7 @@ static bool pathExists(const std::wstring &path)
 static std::wstring findAgentProgram()
 {
     std::wstring progDir = dirname(getModuleFileName(getCurrentModule()));
-    std::wstring ret = progDir + L"\\"AGENT_EXE;
+    std::wstring ret = progDir + (L"\\" AGENT_EXE);
     assert(pathExists(ret));
     return ret;
 }


### PR DESCRIPTION
…erals

`CSI"1;1H"CSI"2J"` does not compile with newer versions of MSVC, because `"1;1H"CSI` is now interpreted as a C++11 user-defined literal.  It's one of the breaking changes between C++03 and C++11.

Fix it by inserting spaces.

This has already been fixed in upstream winpty.
